### PR TITLE
Bump lodash from 4.17.19 to 4.17.21 in /server

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -489,9 +489,9 @@
             "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA="
         },
         "lodash": {
-            "version": "4.17.19",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lowdb": {
             "version": "1.0.0",


### PR DESCRIPTION
[server/package-lock.json](mahgadgi) Bumps [lodash](https://github.com/lodash/lodash) from 4.17.19 to 4.17.21.
- [Release notes](https://github.com/lodash/lodash/releases)
- [Commits](https://github.com/lodash/lodash/compare/4.17.19...4.17.21)

Signed-off-by: dependabot[bot] <support@github.com>